### PR TITLE
Update ValidModel.php

### DIFF
--- a/src/Sudzy/ValidModel.php
+++ b/src/Sudzy/ValidModel.php
@@ -93,7 +93,13 @@ abstract class ValidModel extends \Model
     public function validateProperty($prop, $value, $throw = false)
     {
         $this->lazyLoadValidations();
-
+        
+        // If prop is actaully an Array by using Model->set(Array), return true to prevent warnings from unset()
+        if (is_array($prop))
+        {
+            return true;
+        }
+        
         unset($this->_validationErrors[$prop]);
         unset($this->_validationExceptions[$prop]);
 


### PR DESCRIPTION
Prevent warnings on unset if validateProperty() has been passed an Array in for $prop, which seems to be an issue when saving data using `Model->set( ['key' => 'value'] )`